### PR TITLE
Modify primary key of platform_transaction_model

### DIFF
--- a/web_backend/migrations/versions/f4c458351308_.py
+++ b/web_backend/migrations/versions/f4c458351308_.py
@@ -54,14 +54,14 @@ def upgrade():
     )
     op.create_table(
         "platform_transaction",
-        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("transaction_hash", sa.String(), nullable=False),
         sa.Column("amount", sa.Float(), nullable=False),
         sa.Column("timestamp", postgresql.TIMESTAMP(), nullable=False),
         sa.Column("buyer_name", sa.String(), nullable=True),
         sa.Column("dealer_name", sa.String(), nullable=True),
         sa.ForeignKeyConstraint(["buyer_name"], ["buyer.name"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(["dealer_name"], ["dealer.name"], ondelete="CASCADE"),
-        sa.PrimaryKeyConstraint("id"),
+        sa.PrimaryKeyConstraint("transaction_hash"),
     )
     op.create_table(
         "transaction",

--- a/web_backend/models/platform_transaction_model.py
+++ b/web_backend/models/platform_transaction_model.py
@@ -1,7 +1,7 @@
 """Actual transaction with the platform in terms of USDC."""
 from datetime import datetime
 
-from sqlalchemy import Column, Float, ForeignKey, Integer, String
+from sqlalchemy import Column, Float, ForeignKey, String
 from sqlalchemy.dialects.postgresql import TIMESTAMP
 from db import flask_db
 
@@ -9,7 +9,7 @@ from db import flask_db
 class PlatformTransaction(flask_db.Model):
     """Transactions that refer to actual monetary transactions."""
 
-    id = Column(Integer, primary_key=True)
+    transaction_hash = Column(String, primary_key=True)
     amount = Column(Float, nullable=False)
     timestamp = Column(TIMESTAMP, nullable=False, default=datetime.now)
     buyer_name = Column(String, ForeignKey("buyer.name", ondelete="CASCADE"))


### PR DESCRIPTION
Use ehtereum hash as the primary key of platform transactions.