### PR TITLE
Create index deal by NFT name

### DIFF
--- a/web_backend/dal/deal_dal.py
+++ b/web_backend/dal/deal_dal.py
@@ -77,16 +77,15 @@ def create_deal(
         )
     dealer.lockup_balance = Dealer.lockup_balance + amount_needed
     extra_info: Dict[str, Any] = {}
-    # TODO(Is the logit reversed here? is_nft_index=True -> index branch)
     if is_nft_index:
-        # TODO(Improve later: currently using collection_id field to hold index cmc_id)
-        try:
-            cmc_id = int(collection_id)
-        except ValueError as e:
-            raise Exception("index not fed with correct id") from e
+        # Currently using index name to create index deal
+        # TODO(Improve later: currently using collection_id field to hold index cmc_name)
+        cmc_name = collection_id
+        extra_info["cmc_name"] = cmc_name
+        info = get_info_index(extra_info, with_name=True)
+        collection_name = cmc_name
+        cmc_id = get_not_none(info, "id")
         extra_info["cmc_id"] = cmc_id
-        info = get_info_index(extra_info)
-        collection_name = get_not_none(info, "fullname")
     else:
         info = get_deal_info_with_ids(collection_id, asset_id)
         collection_name = get_not_none(info, "collection_name")

--- a/web_backend/nft_utils/deal_info.py
+++ b/web_backend/nft_utils/deal_info.py
@@ -111,7 +111,7 @@ def get_info_asset(contract, token_id):
     return info
 
 
-def get_info_index(index_metadata):
+def get_info_index(index_metadata, with_name=False):
     """Return info of an index
 
     Args:
@@ -120,8 +120,10 @@ def get_info_index(index_metadata):
     Returns:
         dict: keys: [id(int), name(str), cmc_url(str), fullname(str), url(str)]
     """
+    if with_name:
+        cmc_name = index_metadata["cmc_name"]
+        return cmc_get_index_info_by_name(cmc_name)
     cmc_id = index_metadata["cmc_id"]
-    # cmc_name = index_metadata['cmc_name']
     return cmc_get_index_info_by_id(cmc_id)
 
 


### PR DESCRIPTION
Modified related functions to fix index dael creation problem.
* Now index are created based on coinmarketcap "convert_name".
* The name is passed in create-deal route using `collection_id` field
* When creating index deal, deal extra_info column will have two required fields: {'cmc_id': index id, 'cmc_name': index name} 